### PR TITLE
RS School: AWS Task 7

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,11 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack
+
+.env

--- a/authorization-service/.vscode/launch.json
+++ b/authorization-service/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "name": "Lambda",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["--inspect", "--debug-port=9229"],
+      "program": "${workspaceFolder}/node_modules/serverless/bin/serverless",
+      "args": ["offline"],
+      "port": 9229,
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/authorization-service/handler.ts
+++ b/authorization-service/handler.ts
@@ -1,0 +1,4 @@
+import 'source-map-support/register';
+import basicAuthorizer from './handlers/basicAuthorizer';
+
+export { basicAuthorizer };

--- a/authorization-service/handlers/basicAuthorizer.ts
+++ b/authorization-service/handlers/basicAuthorizer.ts
@@ -1,0 +1,36 @@
+import { APIGatewayTokenAuthorizerHandler, PolicyDocument } from 'aws-lambda';
+
+const basicAuthorizer: APIGatewayTokenAuthorizerHandler = async (event) => {
+
+  if (event.type !== 'TOKEN')
+    throw 'Unauthorized';
+
+  try {
+    const principalId = event.authorizationToken.split(' ')[1];
+
+    const [username, password] = Buffer.from(principalId, 'base64').toString('utf-8').split(':');
+    return {
+      principalId,
+      policyDocument: createPolicy(event.methodArn, process.env[username] && process.env[username] === password ? 'Allow' : 'Deny'),
+    };
+    }
+    catch(e){
+      console.log(e);
+      throw `Unauthorized`;
+    }
+
+};
+
+const createPolicy: (resourceArn: string, effect: string) => PolicyDocument = (
+  resourceArn,
+  effect
+) => {
+  return {
+    Version: '2012-10-17',
+    Statement: [
+      { Effect: effect, Resource: resourceArn, Action: 'execute-api:Invoke' },
+    ],
+  };
+};
+
+export default basicAuthorizer;

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Serverless webpack example using Typescript",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "serverless-dotenv-plugin": "^3.1.0",
+    "source-map-support": "^0.5.10"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.17",
+    "@types/node": "^10.12.18",
+    "@types/serverless": "^1.72.5",
+    "fork-ts-checker-webpack-plugin": "^3.0.1",
+    "serverless-webpack": "^5.2.0",
+    "ts-loader": "^5.3.3",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.2.4",
+    "webpack": "^4.29.0",
+    "webpack-node-externals": "^1.7.2"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/authorization-service/serverless.ts
+++ b/authorization-service/serverless.ts
@@ -1,0 +1,45 @@
+import type { Serverless } from 'serverless/aws';
+
+const serverlessConfiguration: Serverless = {
+  service: {
+    name: 'authorization-service',
+    // app and org for use with dashboard.serverless.com
+    // app: your-app-name,
+    // org: your-org-name,
+  },
+  frameworkVersion: '2',
+  custom: {
+    webpack: {
+      webpackConfig: './webpack.config.js',
+      includeModules: true,
+    },
+  },
+  // Add the serverless-webpack plugin
+  plugins: ['serverless-webpack', 'serverless-dotenv-plugin'],
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs12.x',
+    region: 'eu-west-1',
+    apiGateway: {
+      minimumCompressionSize: 1024,
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+    },
+  },
+  functions: {
+    basicAuthorizer: {
+      handler: 'handler.basicAuthorizer',
+    },
+  },
+  resources: {
+    Resources: {},
+    Outputs: {
+      basicAuthorizerArn: {
+        Value: { 'Fn::GetAtt': ['BasicAuthorizerLambdaFunction', 'Arn'] },
+      },
+    },
+  },
+};
+
+module.exports = serverlessConfiguration;

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/authorization-service/webpack.config.js
+++ b/authorization-service/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'cheap-module-eval-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [
+    // new ForkTsCheckerWebpackPlugin({
+    //   eslint: true,
+    //   eslintOptions: {
+    //     cache: true
+    //   }
+    // })
+  ],
+};

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -60,6 +60,13 @@ const serverlessConfiguration: Serverless = {
                 },
               },
             },
+            authorizer: {
+              name: 'basicTokenAuthorizer',
+              arn:
+                '${cf:authorization-service-${self:provider.stage}.basicAuthorizerArn}',
+              type: 'token',
+              identitySource: 'method.request.header.Authorization',
+            },
           },
         },
       ],
@@ -76,6 +83,32 @@ const serverlessConfiguration: Serverless = {
           },
         },
       ],
+    },
+  },
+  resources: {
+    Resources: {
+      GatewayResponseAccessDenied: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          ResponseType: 'ACCESS_DENIED',
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+            'gatewayresponse.header.Access-Control-Allow-Credentials': "'true'",
+          },
+        },
+      },
+      GatewayResponseUnauthorized: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          RestApiId: { Ref: 'ApiGatewayRestApi' },
+          ResponseType: 'UNAUTHORIZED',
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+            'gatewayresponse.header.Access-Control-Allow-Credentials': "'true'",
+          },
+        },
+      },
     },
   },
 };


### PR DESCRIPTION
**Implemented in product-service:**
 - authorization-service and basicAuthorizer lambda function
 - importProductsFile lambda  has authorizer configuration
 - FE application updated with Authorization header to be sent (correct token is _a2FnYWZvbjpURVNUX1BBU1NXT1JE_)
 - Client application displays alerts for the responses in 401 and 403 HTTP statuses

Total: **6**


FE link:
https://d1mi29n8b3y4rd.cloudfront.net/

FE PR:
https://github.com/kagafon/nodejs-aws-fe/pull/5

CSV example:
https://github.com/kagafon/nodejs-aws-be/blob/task-7/import-service/data/example.csv
